### PR TITLE
ARTEMIS-1498

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -113,6 +113,9 @@ public interface Message {
     */
    SimpleString HDR_GROUP_ID = new SimpleString("_AMQ_GROUP_ID");
 
+   SimpleString HDR_GROUP_SEQUENCE = new SimpleString("_AMQ_GROUP_SEQUENCE");
+
+
    /**
     * to determine if the Large Message was compressed.
     */
@@ -240,6 +243,18 @@ public interface Message {
 
    default SimpleString getGroupID() {
       return null;
+   }
+
+   default Message setGroupID(SimpleString groupID) {
+      return this;
+   }
+
+   default Integer getGroupSequence() {
+      return null;
+   }
+
+   default Message setGroupSequence(Integer groupSequence) {
+      return this;
    }
 
    SimpleString getReplyTo();

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -283,6 +283,30 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
       return this.getSimpleStringProperty(Message.HDR_GROUP_ID);
    }
 
+   @Override
+   public CoreMessage setGroupID(SimpleString groupID) {
+      return this.putStringProperty(Message.HDR_GROUP_ID, groupID);
+   }
+
+   @Override
+   public Integer getGroupSequence() {
+      if (containsProperty(Message.HDR_GROUP_SEQUENCE)) {
+         return this.getIntProperty(Message.HDR_GROUP_SEQUENCE);
+      } else {
+         return null;
+      }
+   }
+
+   @Override
+   public CoreMessage setGroupSequence(Integer groupSequence) {
+      if (groupSequence == null) {
+         this.removeProperty(Message.HDR_GROUP_SEQUENCE);
+      } else {
+         return this.putIntProperty(Message.HDR_GROUP_SEQUENCE, groupSequence);
+      }
+      return this;
+   }
+
    /**
     * @param sendBuffer
     * @param deliveryCount Some protocols (AMQP) will have this as part of the message. ignored on core

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
@@ -49,6 +49,8 @@ public class MessageUtil {
 
    public static final String JMSXGROUPID = "JMSXGroupID";
 
+   public static final String JMSXGROUPSEQUENCE = "JMSXGroupSequence";
+
    public static final String JMSXUSERID = "JMSXUserID";
 
    public static final SimpleString CONNECTION_ID_PROPERTY_NAME = new SimpleString("__AMQ_CID");
@@ -167,6 +169,7 @@ public class MessageUtil {
    public static boolean propertyExists(Message message, String name) {
       return message.containsProperty(new SimpleString(name)) || name.equals(MessageUtil.JMSXDELIVERYCOUNT) ||
          (MessageUtil.JMSXGROUPID.equals(name) && message.containsProperty(Message.HDR_GROUP_ID)) ||
+         (MessageUtil.JMSXGROUPSEQUENCE.equals(name) && message.containsProperty(Message.HDR_GROUP_SEQUENCE)) ||
          (MessageUtil.JMSXUSERID.equals(name) && message.containsProperty(Message.HDR_VALIDATED_USER));
    }
 }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
@@ -543,7 +543,9 @@ public class ActiveMQMessage implements javax.jms.Message {
       if (MessageUtil.JMSXDELIVERYCOUNT.equals(name)) {
          return message.getDeliveryCount();
       }
-
+      if (MessageUtil.JMSXGROUPSEQUENCE.equals(name)) {
+         return message.getGroupSequence();
+      }
       try {
          return message.getIntProperty(name);
       } catch (ActiveMQPropertyConversionException e) {
@@ -555,6 +557,9 @@ public class ActiveMQMessage implements javax.jms.Message {
    public long getLongProperty(final String name) throws JMSException {
       if (MessageUtil.JMSXDELIVERYCOUNT.equals(name)) {
          return message.getDeliveryCount();
+      }
+      if (MessageUtil.JMSXGROUPSEQUENCE.equals(name)) {
+         return message.getGroupSequence();
       }
 
       try {
@@ -641,12 +646,18 @@ public class ActiveMQMessage implements javax.jms.Message {
    @Override
    public void setIntProperty(final String name, final int value) throws JMSException {
       checkProperty(name);
+      if (handleCoreProperty(name, value, MessageUtil.JMSXGROUPSEQUENCE, org.apache.activemq.artemis.api.core.Message.HDR_GROUP_SEQUENCE)) {
+         return;
+      }
       message.putIntProperty(name, value);
    }
 
    @Override
    public void setLongProperty(final String name, final long value) throws JMSException {
       checkProperty(name);
+      if (handleCoreProperty(name, value, MessageUtil.JMSXGROUPSEQUENCE, org.apache.activemq.artemis.api.core.Message.HDR_GROUP_SEQUENCE)) {
+         return;
+      }
       message.putLongProperty(name, value);
    }
 
@@ -678,6 +689,10 @@ public class ActiveMQMessage implements javax.jms.Message {
    @Override
    public void setObjectProperty(final String name, final Object value) throws JMSException {
       if (handleCoreProperty(name, value, MessageUtil.JMSXGROUPID, org.apache.activemq.artemis.api.core.Message.HDR_GROUP_ID)) {
+         return;
+      }
+
+      if (handleCoreProperty(name, value, MessageUtil.JMSXGROUPSEQUENCE, org.apache.activemq.artemis.api.core.Message.HDR_GROUP_SEQUENCE)) {
          return;
       }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -319,6 +319,39 @@ public class AMQPMessage extends RefCountMessage {
    }
 
    @Override
+   public org.apache.activemq.artemis.api.core.Message setGroupID(SimpleString groupId) {
+      Properties properties = getProperties();
+      if (properties != null) {
+         properties.setGroupId(groupId.toString());
+      }
+      return this;
+   }
+
+   @Override
+   public Integer getGroupSequence() {
+      parseHeaders();
+
+      if (_properties != null && _properties.getGroupSequence() != null) {
+         return _properties.getGroupSequence().intValue();
+      } else {
+         return 0;
+      }
+   }
+
+   @Override
+   public org.apache.activemq.artemis.api.core.Message setGroupSequence(Integer groupSequence) {
+      Properties properties = getProperties();
+      if (properties != null) {
+         if (groupSequence != null) {
+            properties.setGroupSequence(UnsignedInteger.valueOf(groupSequence));
+         } else {
+            properties.setGroupSequence(null);
+         }
+      }
+      return this;
+   }
+
+   @Override
    public Long getScheduledDeliveryTime() {
 
       if (scheduledTime < 0) {
@@ -992,6 +1025,8 @@ public class AMQPMessage extends RefCountMessage {
          return getConnectionID();
       } else if (key.equals(MessageUtil.JMSXGROUPID)) {
          return getGroupID();
+      } else if (key.equals(MessageUtil.JMSXGROUPSEQUENCE)) {
+         return getGroupSequence();
       } else if (key.equals(MessageUtil.JMSXUSERID)) {
          return getAMQPUserID();
       } else if (key.equals(MessageUtil.CORRELATIONID_HEADER_NAME.toString())) {

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
@@ -56,7 +56,11 @@ public class StompUtils {
 
       String groupID = headers.remove(MessageUtil.JMSXGROUPID);
       if (groupID != null) {
-         msg.putStringProperty(Message.HDR_GROUP_ID, SimpleString.toSimpleString(groupID));
+         msg.setGroupID(SimpleString.toSimpleString(groupID));
+      }
+      String groupSequence = headers.remove(MessageUtil.JMSXGROUPSEQUENCE);
+      if (groupSequence != null) {
+         msg.setGroupSequence(Integer.valueOf(groupSequence));
       }
       String contentType = headers.remove(Stomp.Headers.CONTENT_TYPE);
       if (contentType != null) {

--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -61,6 +61,12 @@
          <version>${project.version}</version>
          <type>test-jar</type>
       </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-junit</artifactId>
+         <version>${project.version}</version>
+         <type>test-jar</type>
+      </dependency>
 
       <!-- I imported this to get a mock of a class -->
       <dependency>

--- a/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/artemiswrapper/OpenwireArtemisBaseTest.java
+++ b/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/artemiswrapper/OpenwireArtemisBaseTest.java
@@ -33,7 +33,7 @@ import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS;
-import org.apache.activemq.artemis.utils.ThreadLeakCheckRule;
+import org.apache.activemq.artemis.junit.ThreadLeakCheckRule;
 import org.apache.activemq.artemis.utils.uri.URISupport;
 import org.apache.activemq.broker.BrokerService;
 import org.junit.Assert;


### PR DESCRIPTION
Expose setGroupID as top level Message method, as getGroupId already is, and update all.

Expose setGroupSequence and getGroupSequence as a top level Messsage method as is JMS spec defined (behaviour is not) 

Use object pools in open wire message

Update activemq5 unit tests to use artemis-junit (seems class was moved at somepoint)